### PR TITLE
feat(menu-bar): 添加状态栏服务器菜单与快捷控制

### DIFF
--- a/SwiftCraftServerLauncher/Common/Views/MenuBar/ServerStatusMenuBarView.swift
+++ b/SwiftCraftServerLauncher/Common/Views/MenuBar/ServerStatusMenuBarView.swift
@@ -1,0 +1,195 @@
+import SwiftUI
+
+struct ServerStatusMenuBarView: View {
+    @EnvironmentObject private var serverRepository: ServerRepository
+    @ObservedObject private var statusManager = ServerStatusManager.shared
+    @ObservedObject private var generalSettings = GeneralSettingsManager.shared
+
+    private var runningServersCount: Int {
+        serverRepository.servers.filter { statusManager.isServerRunning(serverId: $0.id) }.count
+    }
+
+    var body: some View {
+        Group {
+            if serverRepository.servers.isEmpty {
+                ContentUnavailableView(
+                    "menubar.servers.empty".localized(),
+                    systemImage: "server.rack"
+                )
+            } else {
+                serverList
+            }
+        }
+    }
+
+    private var serverList: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(String(format: "menubar.servers.summary".localized(), runningServersCount, serverRepository.servers.count))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Divider()
+
+            ForEach(serverRepository.servers) { server in
+                Menu {
+                    ForEach(sectionItems(for: server)) { item in
+                        Button {
+                            guard item.isEnabled else { return }
+                            ServerDetailWindowCoordinator.shared.open(
+                                serverId: server.id,
+                                preferredSection: item.section
+                            )
+                        } label: {
+                            Label(item.title, systemImage: item.icon)
+                        }
+                        .disabled(!item.isEnabled)
+                    }
+                } label: {
+                    HStack {
+                        Image(systemName: statusIconName(for: server))
+                            .foregroundStyle(statusColor(for: server))
+                        Text(server.name)
+                        Spacer()
+                        Text(statusText(for: server))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+    }
+
+    private struct SectionItem: Identifiable {
+        let section: String
+        let title: String
+        let icon: String
+        let isEnabled: Bool
+
+        var id: String { section }
+    }
+
+    private func sectionItems(for server: ServerInstance) -> [SectionItem] {
+        var items: [SectionItem] = []
+        if generalSettings.serverTabConsoleEnabled {
+            items.append(.init(
+                section: "console",
+                title: "server.console.title".localized(),
+                icon: "terminal",
+                isEnabled: true
+            ))
+        }
+        if generalSettings.serverTabConfigEnabled {
+            items.append(.init(
+                section: "serverConfig",
+                title: "server.launch.server_config".localized(),
+                icon: "folder",
+                isEnabled: true
+            ))
+        }
+        if generalSettings.serverTabPlayersEnabled {
+            items.append(.init(
+                section: "players",
+                title: "server.launch.players".localized(),
+                icon: "person.3",
+                isEnabled: true
+            ))
+        }
+        if generalSettings.serverTabWorldsEnabled {
+            items.append(.init(
+                section: "worlds",
+                title: "server.launch.worlds".localized(),
+                icon: "globe.americas",
+                isEnabled: true
+            ))
+        }
+        if generalSettings.serverTabModsEnabled {
+            items.append(.init(
+                section: "mods",
+                title: disabledTitle(
+                    "server.launch.mods".localized(),
+                    hint: supportsMods(server) ? nil : "server.launch.hint.mods_only".localized()
+                ),
+                icon: "puzzlepiece.extension",
+                isEnabled: supportsMods(server)
+            ))
+        }
+        if generalSettings.serverTabPluginsEnabled {
+            items.append(.init(
+                section: "plugins",
+                title: disabledTitle(
+                    "server.launch.plugins".localized(),
+                    hint: supportsPlugins(server) ? nil : "server.launch.hint.plugins_only".localized()
+                ),
+                icon: "powerplug",
+                isEnabled: supportsPlugins(server)
+            ))
+        }
+        if generalSettings.serverTabSchedulesEnabled {
+            items.append(.init(
+                section: "schedules",
+                title: "server.schedules.title".localized(),
+                icon: "clock.arrow.circlepath",
+                isEnabled: true
+            ))
+        }
+        if generalSettings.serverTabLogsEnabled {
+            items.append(.init(
+                section: "logs",
+                title: "server.logs.title".localized(),
+                icon: "doc.text.magnifyingglass",
+                isEnabled: true
+            ))
+        }
+        if items.isEmpty {
+            items.append(.init(
+                section: "console",
+                title: "server.console.title".localized(),
+                icon: "terminal",
+                isEnabled: true
+            ))
+        }
+        return items
+    }
+
+    private func supportsMods(_ server: ServerInstance) -> Bool {
+        server.serverType == .fabric || server.serverType == .forge
+    }
+
+    private func supportsPlugins(_ server: ServerInstance) -> Bool {
+        server.serverType == .paper
+    }
+
+    private func disabledTitle(_ title: String, hint: String?) -> String {
+        guard let hint else { return title }
+        return "\(title)  \(hint)"
+    }
+
+    private func statusText(for server: ServerInstance) -> String {
+        if statusManager.isServerLaunching(serverId: server.id) {
+            return "menubar.servers.status.launching".localized()
+        }
+        if statusManager.isServerRunning(serverId: server.id) {
+            return "menubar.servers.status.running".localized()
+        }
+        return "menubar.servers.status.stopped".localized()
+    }
+
+    private func statusIconName(for server: ServerInstance) -> String {
+        if statusManager.isServerLaunching(serverId: server.id) {
+            return "clock.fill"
+        }
+        if statusManager.isServerRunning(serverId: server.id) {
+            return "circle.fill"
+        }
+        return "circle"
+    }
+
+    private func statusColor(for server: ServerInstance) -> Color {
+        if statusManager.isServerLaunching(serverId: server.id) {
+            return .orange
+        }
+        if statusManager.isServerRunning(serverId: server.id) {
+            return .green
+        }
+        return .secondary
+    }
+}

--- a/SwiftCraftServerLauncher/Common/Views/Settings/AppearanceSettingsView.swift
+++ b/SwiftCraftServerLauncher/Common/Views/Settings/AppearanceSettingsView.swift
@@ -3,11 +3,14 @@ import SwiftUI
 public struct AppearanceSettingsView: View {
     @StateObject private var themeManager = ThemeManager.shared
     @StateObject private var generalSettings = GeneralSettingsManager.shared
+    @AppStorage("showServerStatusMenuBar")
+    private var showServerStatusMenuBar = true
 
     private let defaultThemeMode: ThemeMode = .system
     private let defaultEnableConsoleColoredOutput = true
     private let defaultServerFileManagerShowShortcuts = true
     private let defaultOpenServerInNewWindow = false
+    private let defaultShowServerStatusMenuBar = true
 
     public init() {}
 
@@ -169,6 +172,18 @@ public struct AppearanceSettingsView: View {
 
                             resetIconButton(disabled: generalSettings.openServerInNewWindow == defaultOpenServerInNewWindow) {
                                 generalSettings.openServerInNewWindow = defaultOpenServerInNewWindow
+                            }
+                        }
+                    }
+                    .labeledContentStyle(.custom)
+
+                    LabeledContent("settings.server.show_status_menubar".localized()) {
+                        HStack(alignment: .top, spacing: 8) {
+                            Toggle("", isOn: $showServerStatusMenuBar)
+                                .labelsHidden()
+
+                            resetIconButton(disabled: showServerStatusMenuBar == defaultShowServerStatusMenuBar) {
+                                showServerStatusMenuBar = defaultShowServerStatusMenuBar
                             }
                         }
                     }

--- a/SwiftCraftServerLauncher/Resources/Localizable.xcstrings
+++ b/SwiftCraftServerLauncher/Resources/Localizable.xcstrings
@@ -19854,6 +19854,125 @@
           }
         }
       }
+    },
+    "menubar.servers.empty": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No servers"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暂无服务器"
+          }
+        }
+      }
+    },
+    "menubar.servers.status.launching": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Starting"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启动中"
+          }
+        }
+      }
+    },
+    "menubar.servers.status.running": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Running"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "运行中"
+          }
+        }
+      }
+    },
+    "menubar.servers.status.stopped": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stopped"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已停止"
+          }
+        }
+      }
+    },
+    "menubar.servers.summary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld/%lld running"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld/%lld 运行中"
+          }
+        }
+      }
+    },
+    "menubar.servers.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Servers"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "服务器"
+          }
+        }
+      }
+    },
+    "settings.server.show_status_menubar": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show servers in menu bar"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在状态栏显示服务器"
+          }
+        }
+      }
     }
   },
   "version": "1.1"

--- a/SwiftCraftServerLauncher/SwiftCraftLauncherApp.swift
+++ b/SwiftCraftServerLauncher/SwiftCraftLauncherApp.swift
@@ -14,6 +14,9 @@ struct SwiftCraftServerLauncherApp: App {
     @Environment(\.openWindow)
     private var openWindow
 
+    @AppStorage("showServerStatusMenuBar")
+    private var showServerStatusMenuBar = true
+
     // MARK: - StateObjects
     @StateObject var gameRepository = GameRepository()
     @StateObject var serverRepository = ServerRepository()
@@ -144,5 +147,15 @@ struct SwiftCraftServerLauncherApp: App {
         }
 
         appWindowGroups()
+
+        MenuBarExtra(
+            "menubar.servers.title".localized(),
+            systemImage: "server.rack",
+            isInserted: $showServerStatusMenuBar
+        ) {
+            ServerStatusMenuBarView()
+                .environmentObject(serverRepository)
+        }
+        .menuBarExtraStyle(.menu)
     }
 }


### PR DESCRIPTION
## 变更说明
- 添加状态栏服务器菜单
- 支持在状态栏中快速启动、停止服务器
- 支持展开进入控制台、文件管理、玩家管理等页面
- 补充相关设置项与本地化文案

## 验证
- 已通过 SwiftLint
- 已通过 Debug 构建